### PR TITLE
JIT get_reduced_triangular

### DIFF
--- a/steenroder/__init__.py
+++ b/steenroder/__init__.py
@@ -33,7 +33,7 @@ def get_coboundary(filtration):
 
 @njit
 def get_reduced_triangular(matrix, homology=False):
-    '''R = MV'''
+    """R = MV"""
 
     # # if a filtration is passed
     # if isinstance(matrix, tuple):
@@ -244,7 +244,7 @@ def get_steenrod_barcode(reduced, steenrod_matrix):
 
 
 def barcodes(k, filtration):
-    '''serves as the main function'''
+    """Serves as the main function"""
 
     coboundary = get_coboundary(filtration)
     reduced, triangular = get_reduced_triangular(coboundary)

--- a/steenroder/__init__.py
+++ b/steenroder/__init__.py
@@ -11,6 +11,17 @@ def _pivot(column):
     return -1
 
 
+@njit
+def _are_pivots_same(column_1, column_2):
+    # Assumes column_1 and column_2 have the same length
+    for i in range(len(column_1) - 1, -1, -1):
+        if column_1[i] or column_2[i]:
+            if column_1[i] and column_2[i]:
+                return True
+            return False
+    return False
+
+
 def get_boundary(filtration):
     spx_filtration_idx = {tuple(v): idx for idx, v in enumerate(filtration)}
     boundary = np.zeros((len(filtration), len(filtration)), dtype=bool)
@@ -53,10 +64,7 @@ def get_reduced_triangular(matrix, homology=False):
             if not np.any(reduced[:, j]):
                 break
             else:
-                piv_j = _pivot(reduced[:, j])
-                piv_i = _pivot(reduced[:, i])
-
-                if piv_i == piv_j:
+                if _are_pivots_same(reduced[:, j], reduced[:, i]):
                     reduced[:, j] = np.logical_xor(
                         reduced[:, i], reduced[:, j])
                     triangular[:, j] = np.logical_xor(
@@ -204,10 +212,7 @@ def reduce_vector(reduced, vector, num_col):
         if not np.any(vector):
             break
         else:
-            piv_v = _pivot(vector)
-            piv_i = _pivot(reduced[:, i])
-
-            if piv_i == piv_v:
+            if _are_pivots_same(vector, reduced[:, i]):
                 vector[:] = np.logical_xor(vector, reduced[:, i])
                 i = 0
             i -= 1

--- a/steenroder/__init__.py
+++ b/steenroder/__init__.py
@@ -5,9 +5,9 @@ from numba import njit
 
 @njit
 def _pivot(column):
-    nonzero = column.nonzero()[0]
-    if len(nonzero):
-        return max(nonzero)
+    for i in range(len(column) - 1, -1, -1):
+        if column[i]:
+            return i
     return -1
 
 
@@ -208,7 +208,7 @@ def reduce_vector(reduced, vector, num_col):
             piv_i = _pivot(reduced[:, i])
 
             if piv_i == piv_v:
-                vector[:, 0] = np.logical_xor(vector[:, 0], reduced[:, i])
+                vector[:] = np.logical_xor(vector, reduced[:, i])
                 i = 0
             i -= 1
 
@@ -221,7 +221,7 @@ def reduce_matrix(reduced, matrix):
     reducing[:, :reduced.shape[1]] = reduced
 
     for i in range(num_vector):
-        reduce_vector(reducing, matrix[:, i:i + 1], reduced.shape[1] + i)
+        reduce_vector(reducing, matrix[:, i], reduced.shape[1] + i)
         reducing[:, reduced.shape[1] + i] = matrix[:, i]
 
 

--- a/steenroder/__init__.py
+++ b/steenroder/__init__.py
@@ -5,10 +5,10 @@ from numba import njit
 
 @njit
 def _pivot(column):
-    try:
-        return max(column.nonzero()[0])
-    except:
-        return -1
+    nonzero = column.nonzero()[0]
+    if len(nonzero):
+        return max(nonzero)
+    return -1
 
 
 def get_boundary(filtration):
@@ -31,19 +31,21 @@ def get_coboundary(filtration):
     return coboundary
 
 
+@njit
 def get_reduced_triangular(matrix, homology=False):
     '''R = MV'''
 
-    # if a filtration is passed
-    if isinstance(matrix, tuple):
-        matrix = get_boundary(matrix)
-        if not homology:
-            matrix = np.flip(matrix, axis=[0, 1]).transpose()
+    # # if a filtration is passed
+    # if isinstance(matrix, tuple):
+    #     matrix = get_boundary(matrix)
+    #     if not homology:
+    #         matrix = np.flip(matrix, axis=[0, 1]).transpose()
 
     # reduction steps
     n = matrix.shape[1]
-    reduced = np.array(matrix)
-    triangular = np.eye(n, dtype=bool)
+    reduced = matrix.copy()
+    triangular = np.zeros((n, n), dtype=np.bool_)
+    np.fill_diagonal(triangular, True)
     for j in range(n):
         i = j
         while i > 0:

--- a/steenroder/__init__.py
+++ b/steenroder/__init__.py
@@ -44,7 +44,7 @@ def get_reduced_triangular(matrix, homology=False):
     # reduction steps
     n = matrix.shape[1]
     reduced = matrix.copy()
-    triangular = np.zeros((n, n), dtype=np.bool_)
+    triangular = np.zeros((n, n), dtype=np.bool_).T
     np.fill_diagonal(triangular, True)
     for j in range(n):
         i = j
@@ -216,8 +216,8 @@ def reduce_vector(reduced, vector, num_col):
 @njit
 def reduce_matrix(reduced, matrix):
     num_vector = matrix.shape[1]
-    reducing = np.empty((reduced.shape[0], reduced.shape[1] + num_vector),
-                        dtype=reduced.dtype)
+    reducing = np.empty((reduced.shape[1] + num_vector, reduced.shape[0]),
+                        dtype=reduced.dtype).T
     reducing[:, :reduced.shape[1]] = reduced
 
     for i in range(num_vector):

--- a/steenroder/__init__.py
+++ b/steenroder/__init__.py
@@ -153,7 +153,7 @@ def STSQ(k, cocycle, filtration):
             index_b = {index[w] for w in b_bar}
             if (index_a == {0} and index_b == {1}
                     or index_a == {1} and index_b == {0}):
-                answer.add(tuple(u))
+                answer ^= {tuple(u)}
 
     return answer
 


### PR DESCRIPTION
When added to previous jitting, 10x speedup in the simple example used so far is achieved.  But I had to give up the possibility that `matrix` be a tuple (or else it won't compile, at least not in this form).